### PR TITLE
Add Script tag with AMF3 content.

### DIFF
--- a/lib/flvlib/constants.py
+++ b/lib/flvlib/constants.py
@@ -3,7 +3,10 @@ The constants used in FLV files and their meanings.
 """
 
 # Tag type
-(TAG_TYPE_AUDIO, TAG_TYPE_VIDEO, TAG_TYPE_SCRIPT) = (8, 9, 18)
+(TAG_TYPE_AUDIO,
+ TAG_TYPE_VIDEO,
+ TAG_TYPE_SCRIPT_AMF3,
+ TAG_TYPE_SCRIPT) = (8, 9, 15, 18)
 
 
 # Sound format

--- a/lib/flvlib/tags.py
+++ b/lib/flvlib/tags.py
@@ -238,10 +238,24 @@ class ScriptTag(Tag):
                     (self.name, self.offset, self.timestamp, self.size))
 
 
+class ScriptAmf3Tag(Tag):
+
+    def __init__(self, parent_flv, f):
+        Tag.__init__(self, parent_flv, f)
+
+    def __repr__(self):
+        if self.offset is None:
+            return "<ScriptAmf3Tag unparsed>"
+        else:
+            return ("<ScriptAmf3Tag at offset 0x%08X, time %d, size %d>" %
+                    (self.offset, self.timestamp, self.size))
+
+
 tag_to_class = {
     TAG_TYPE_AUDIO: AudioTag,
     TAG_TYPE_VIDEO: VideoTag,
-    TAG_TYPE_SCRIPT: ScriptTag
+    TAG_TYPE_SCRIPT: ScriptTag,
+    TAG_TYPE_SCRIPT_AMF3: ScriptAmf3Tag,
 }
 
 

--- a/lib/flvlib/tags.py
+++ b/lib/flvlib/tags.py
@@ -238,24 +238,21 @@ class ScriptTag(Tag):
                     (self.name, self.offset, self.timestamp, self.size))
 
 
-class ScriptAmf3Tag(Tag):
-
-    def __init__(self, parent_flv, f):
-        Tag.__init__(self, parent_flv, f)
+class ScriptAMF3Tag(Tag):
 
     def __repr__(self):
         if self.offset is None:
-            return "<ScriptAmf3Tag unparsed>"
+            return "<ScriptAMF3Tag unparsed>"
         else:
-            return ("<ScriptAmf3Tag at offset 0x%08X, time %d, size %d>" %
+            return ("<ScriptAMF3Tag at offset 0x%08X, time %d, size %d>" %
                     (self.offset, self.timestamp, self.size))
 
 
 tag_to_class = {
     TAG_TYPE_AUDIO: AudioTag,
     TAG_TYPE_VIDEO: VideoTag,
+    TAG_TYPE_SCRIPT_AMF3: ScriptAMF3Tag,
     TAG_TYPE_SCRIPT: ScriptTag,
-    TAG_TYPE_SCRIPT_AMF3: ScriptAmf3Tag,
 }
 
 

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -329,6 +329,34 @@ class TestScriptTag(TestUnderStrictParsing):
                           "time 9823, size 7>")
 
 
+class TestScriptAMF3Tag(TestUnderStrictParsing):
+
+    def test_simple_script_amf3_tag(self):
+        s = StringIO('\x00\x00\x17\x00\x00\x4d\x00\x00\x00\x00' +
+                     '\x00\x02\x00\x0a\x73\x74\x72\x65\x61\x6d' +
+                     '\x50\x69\x6e\x67\x00\x42\x74\x29\xa6\xff' +
+                     '\x4b\x50\x00\x00\x00\x00\x22')
+        t = tags.ScriptAMF3Tag(None, s)
+        t.parse()
+
+        self.assertEquals(t.offset, -1)
+        self.assertEquals(t.size, 23)
+        self.assertEquals(t.timestamp, 77)
+
+    def test_repr(self):
+        s = LStringIO('\x00\x00\x17\x00\x00\x4d\x00\x00\x00\x00' +
+                      '\x00\x02\x00\x0a\x73\x74\x72\x65\x61\x6d' +
+                      '\x50\x69\x6e\x67\x00\x42\x74\x29\xa6\xff' +
+                      '\x4b\x50\x00\x00\x00\x00\x22', 10)
+        t = tags.ScriptAMF3Tag(None, s)
+        self.assertEquals(repr(t), "<ScriptAMF3Tag unparsed>")
+
+        t.parse()
+        self.assertEquals(repr(t),
+                          "<ScriptAMF3Tag at offset 0x00000009, "
+                          "time 77, size 23>")
+
+
 class TestFLV(TestUnderStrictParsing, BodyGeneratorMixin):
 
     def test_simple_parse(self):
@@ -345,6 +373,10 @@ class TestFLV(TestUnderStrictParsing, BodyGeneratorMixin):
                      '\x08' + self.tag_body('\x4b') +
                      '\x08' + self.tag_body('\xbb') +
                      '\x09' + self.tag_body('\x17\x00') +
+                     '\x0f' + ('\x00\x00\x17\x00\x00\x4d\x00\x00\x00\x00' +
+                               '\x00\x02\x00\x0a\x73\x74\x72\x65\x61\x6d' +
+                               '\x50\x69\x6e\x67\x00\x42\x74\x29\xa6\xff' +
+                               '\x4b\x50\x00\x00\x00\x00\x22') +
                      '\x12' + ('\x00\x00\x07\x00\x26\x5f\x00\x00\x00\x00' +
                                '\x02\x00\x03\x66\x6f\x6f\x05\x00\x00\x00\x12'))
         f = tags.FLV(s)
@@ -354,11 +386,12 @@ class TestFLV(TestUnderStrictParsing, BodyGeneratorMixin):
         self.assertEquals(f.has_audio, True)
         self.assertEquals(f.has_video, True)
 
-        self.assertEquals(len(f.tags), 4)
+        self.assertEquals(len(f.tags), 5)
         self.assertTrue(isinstance(f.tags[0], tags.AudioTag))
         self.assertTrue(isinstance(f.tags[1], tags.AudioTag))
         self.assertTrue(isinstance(f.tags[2], tags.VideoTag))
-        self.assertTrue(isinstance(f.tags[3], tags.ScriptTag))
+        self.assertTrue(isinstance(f.tags[3], tags.ScriptAMF3Tag))
+        self.assertTrue(isinstance(f.tags[4], tags.ScriptTag))
 
     def test_errors(self):
         # file shorter than 3 bytes


### PR DESCRIPTION
This doesn't parse the tag, but it at least recognizes it in the stream
and continues on. Wikipedia calls this the RTMP Stream Flex Send tag
while the RTMP docs call it a data tag containing AMF3.
